### PR TITLE
feat: add access request domain model and mock data layer

### DIFF
--- a/src/features/access-requests/mock-data.ts
+++ b/src/features/access-requests/mock-data.ts
@@ -1,6 +1,176 @@
-// Mock data for local development.
-// Placeholder — not yet implemented.
-
 import type { AccessRequest } from "./types";
+import { assertMockDataValid } from "./schema";
 
-export const mockAccessRequests: AccessRequest[] = [];
+const SIMULATED_LATENCY_MS = 400;
+
+// Set to true to simulate a fetch failure for testing error states.
+let simulateError = false;
+
+export function setSimulateError(value: boolean): void {
+  simulateError = value;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const mockAccessRequests: ReadonlyArray<AccessRequest> = [
+  {
+    id: "req_001",
+    requesterName: "Alice Chen",
+    requesterEmail: "alice.chen@company.com",
+    team: "Payments",
+    apiName: "Payment Processing API",
+    environment: "production",
+    accessLevel: "read",
+    status: "approved",
+    submittedAt: "2026-03-10T09:15:00.000Z",
+    justification: "Need read access to reconcile transaction records for quarterly audit.",
+    reviewerNotes: "Standard audit access. Approved.",
+    decision: { reviewedBy: "bob.smith@company.com", reviewedAt: "2026-03-11T14:00:00.000Z" },
+  },
+  {
+    id: "req_002",
+    requesterName: "Marcus Rivera",
+    requesterEmail: "marcus.rivera@company.com",
+    team: "Platform Engineering",
+    apiName: "Infrastructure Metrics API",
+    environment: "staging",
+    accessLevel: "admin",
+    status: "pending",
+    submittedAt: "2026-04-01T11:30:00.000Z",
+    justification:
+      "Setting up a new observability pipeline. Admin access required to configure metric retention policies and create alert routing rules during the staging rollout before we promote to production.",
+  },
+  {
+    id: "req_003",
+    requesterName: "Priya Nair",
+    requesterEmail: "priya.nair@company.com",
+    team: "Data Science",
+    apiName: "Customer Insights API",
+    environment: "production",
+    accessLevel: "read",
+    status: "rejected",
+    submittedAt: "2026-03-20T08:45:00.000Z",
+    justification: "Exploratory analysis for a churn prediction model.",
+    reviewerNotes: "PII exposure risk in production. Please request access to the anonymized staging dataset instead.",
+    decision: { reviewedBy: "carol.james@company.com", reviewedAt: "2026-03-21T10:20:00.000Z" },
+  },
+  {
+    id: "req_004",
+    requesterName: "James Okafor",
+    requesterEmail: "james.okafor@company.com",
+    team: "Mobile",
+    apiName: "Push Notification API",
+    environment: "development",
+    accessLevel: "write",
+    status: "approved",
+    submittedAt: "2026-04-05T13:00:00.000Z",
+    justification: "Building the in-app notification feature for the v4.2 release.",
+    reviewerNotes: "Dev environment only. Approved for sprint duration.",
+    decision: { reviewedBy: "bob.smith@company.com", reviewedAt: "2026-04-05T16:45:00.000Z" },
+  },
+  {
+    id: "req_005",
+    requesterName: "Sofia Lindqvist",
+    requesterEmail: "sofia.lindqvist@company.com",
+    team: "Finance",
+    apiName: "Payment Processing API",
+    environment: "production",
+    accessLevel: "write",
+    status: "pending",
+    submittedAt: "2026-04-18T10:05:00.000Z",
+    justification:
+      "Finance needs write access to initiate refund workflows on behalf of support agents. Currently this is a manual process handled by the Payments team on request, which introduces delays. Automating it here will reduce resolution time from ~2 days to under 1 hour.",
+  },
+  {
+    id: "req_006",
+    requesterName: "Devon Walsh",
+    requesterEmail: "devon.walsh@company.com",
+    team: "Security",
+    apiName: "Audit Log API",
+    environment: "production",
+    accessLevel: "read",
+    status: "approved",
+    submittedAt: "2026-02-14T07:30:00.000Z",
+    justification: "Ongoing SOC 2 compliance monitoring. Security team requires persistent read access.",
+    decision: { reviewedBy: "carol.james@company.com", reviewedAt: "2026-02-14T09:00:00.000Z" },
+  },
+  {
+    id: "req_007",
+    requesterName: "Yuki Tanaka",
+    requesterEmail: "yuki.tanaka@company.com",
+    team: "Growth",
+    apiName: "Customer Insights API",
+    environment: "staging",
+    accessLevel: "read",
+    status: "pending",
+    submittedAt: "2026-04-22T14:20:00.000Z",
+    justification: "A/B test analysis for the onboarding redesign experiment launching next sprint.",
+  },
+  {
+    id: "req_008",
+    requesterName: "Carlos Mendez",
+    requesterEmail: "carlos.mendez@company.com",
+    team: "Platform Engineering",
+    apiName: "Service Registry API",
+    environment: "production",
+    accessLevel: "admin",
+    status: "rejected",
+    submittedAt: "2026-04-10T09:00:00.000Z",
+    justification:
+      "Need admin access to deregister deprecated service instances as part of the microservice consolidation project.",
+    reviewerNotes: "Too broad. Please scope this to a write-level request with specific service IDs listed.",
+    decision: { reviewedBy: "carol.james@company.com", reviewedAt: "2026-04-11T11:30:00.000Z" },
+  },
+  {
+    id: "req_009",
+    requesterName: "Nina Patel",
+    requesterEmail: "nina.patel@company.com",
+    team: "Data Science",
+    apiName: "Infrastructure Metrics API",
+    environment: "staging",
+    accessLevel: "read",
+    status: "approved",
+    submittedAt: "2026-03-28T12:00:00.000Z",
+    justification: "Training a cost-anomaly detection model that needs historical metric data.",
+    decision: { reviewedBy: "bob.smith@company.com", reviewedAt: "2026-03-29T08:15:00.000Z" },
+  },
+  {
+    id: "req_010",
+    requesterName: "Elliot Grant",
+    requesterEmail: "elliot.grant@company.com",
+    team: "Mobile",
+    apiName: "User Profile API",
+    environment: "development",
+    accessLevel: "write",
+    status: "pending",
+    submittedAt: "2026-04-23T16:50:00.000Z",
+    justification: "Implementing profile edit flow for the mobile app redesign.",
+  },
+];
+
+assertMockDataValid(mockAccessRequests);
+
+function cloneAccessRequest(r: AccessRequest): AccessRequest {
+  return { ...r, ...(r.decision ? { decision: { ...r.decision } } : {}) };
+}
+
+export async function fetchAccessRequests(): Promise<AccessRequest[]> {
+  await sleep(SIMULATED_LATENCY_MS);
+  if (simulateError) {
+    throw new Error("[mock] Failed to fetch access requests.");
+  }
+  return mockAccessRequests.map(cloneAccessRequest);
+}
+
+export async function fetchAccessRequestById(
+  id: string
+): Promise<AccessRequest | undefined> {
+  await sleep(SIMULATED_LATENCY_MS);
+  if (simulateError) {
+    throw new Error(`[mock] Failed to fetch access request ${id}.`);
+  }
+  const found = mockAccessRequests.find((r) => r.id === id);
+  return found ? cloneAccessRequest(found) : undefined;
+}

--- a/src/features/access-requests/schema.ts
+++ b/src/features/access-requests/schema.ts
@@ -1,2 +1,74 @@
-// Validation schemas for the access-requests feature.
-// Placeholder — not yet implemented.
+import { AccessLevel, AccessStatus, Environment } from "./types";
+import type { AccessRequest } from "./types";
+
+const VALID_STATUSES = Object.values(AccessStatus);
+const VALID_ENVIRONMENTS = Object.values(Environment);
+const VALID_ACCESS_LEVELS = Object.values(AccessLevel);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isISODateString(value: unknown): value is string {
+  return typeof value === "string" && !isNaN(Date.parse(value));
+}
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; errors: string[] };
+
+export function validateAccessRequest(value: unknown): ValidationResult {
+  if (typeof value !== "object" || value === null) {
+    return { valid: false, errors: ["value must be a non-null object"] };
+  }
+
+  const errors: string[] = [];
+  const r = value as Record<string, unknown>;
+
+  if (!isNonEmptyString(r.id)) errors.push("id must be a non-empty string");
+  if (!isNonEmptyString(r.requesterName)) errors.push("requesterName must be a non-empty string");
+  if (!isNonEmptyString(r.requesterEmail) || !(r.requesterEmail as string).includes("@"))
+    errors.push("requesterEmail must be a valid email");
+  if (!isNonEmptyString(r.team)) errors.push("team must be a non-empty string");
+  if (!isNonEmptyString(r.apiName)) errors.push("apiName must be a non-empty string");
+  if (!VALID_ENVIRONMENTS.includes(r.environment as Environment))
+    errors.push(`environment must be one of: ${VALID_ENVIRONMENTS.join(", ")}`);
+  if (!VALID_ACCESS_LEVELS.includes(r.accessLevel as AccessLevel))
+    errors.push(`accessLevel must be one of: ${VALID_ACCESS_LEVELS.join(", ")}`);
+  if (!VALID_STATUSES.includes(r.status as AccessStatus))
+    errors.push(`status must be one of: ${VALID_STATUSES.join(", ")}`);
+  if (!isISODateString(r.submittedAt)) errors.push("submittedAt must be an ISO date string");
+  if (!isNonEmptyString(r.justification)) errors.push("justification must be a non-empty string");
+
+  if (r.reviewerNotes !== undefined && !isNonEmptyString(r.reviewerNotes))
+    errors.push("reviewerNotes must be a non-empty string if present");
+
+  if (r.decision !== undefined) {
+    if (typeof r.decision !== "object" || r.decision === null) {
+      errors.push("decision must be a non-null object if present");
+    } else {
+      const d = r.decision as Record<string, unknown>;
+      if (!isNonEmptyString(d.reviewedBy)) errors.push("decision.reviewedBy must be a non-empty string");
+      if (!isISODateString(d.reviewedAt)) errors.push("decision.reviewedAt must be an ISO date string");
+    }
+  }
+
+  const status = r.status as AccessStatus;
+  const hasDecision = r.decision !== undefined;
+  if ((status === "approved" || status === "rejected") && !hasDecision)
+    errors.push(`${status} records must include a decision`);
+  if (status === "pending" && hasDecision)
+    errors.push("pending records must not include a decision");
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+/** Throws if any record in the dataset is invalid. Used as a dev-time sanity check. */
+export function assertMockDataValid(records: readonly AccessRequest[]): void {
+  for (const record of records) {
+    const result = validateAccessRequest(record);
+    if (!result.valid) {
+      throw new Error(`Invalid mock record ${record.id}: ${result.errors.join("; ")}`);
+    }
+  }
+}

--- a/src/features/access-requests/types.ts
+++ b/src/features/access-requests/types.ts
@@ -1,6 +1,40 @@
-// Domain types for the access-requests feature.
-// Placeholder — not yet implemented.
+export const AccessStatus = {
+  pending: "pending",
+  approved: "approved",
+  rejected: "rejected",
+} as const;
+export type AccessStatus = (typeof AccessStatus)[keyof typeof AccessStatus];
+
+export const Environment = {
+  development: "development",
+  staging: "staging",
+  production: "production",
+} as const;
+export type Environment = (typeof Environment)[keyof typeof Environment];
+
+export const AccessLevel = {
+  read: "read",
+  write: "write",
+  admin: "admin",
+} as const;
+export type AccessLevel = (typeof AccessLevel)[keyof typeof AccessLevel];
+
+export type DecisionMetadata = {
+  reviewedBy: string;
+  reviewedAt: string; // ISO date string
+};
 
 export type AccessRequest = {
   id: string;
+  requesterName: string;
+  requesterEmail: string;
+  team: string;
+  apiName: string;
+  environment: Environment;
+  accessLevel: AccessLevel;
+  status: AccessStatus;
+  submittedAt: string; // ISO date string
+  justification: string;
+  reviewerNotes?: string;
+  decision?: DecisionMetadata;
 };


### PR DESCRIPTION
## Summary

This PR completes Issue #2 by adding the core access-request domain model, lightweight runtime validation, and a mocked async data layer for the API Access Console.

Closes #2

## What changed

- added explicit access-request domain types in `src/features/access-requests/types.ts`
- added lightweight runtime validation in `src/features/access-requests/schema.ts`
- added a small hand-authored mock dataset in `src/features/access-requests/mock-data.ts`
- added async mock read helpers with simulated latency
- added a simple read-error toggle for later loading/error state testing
- validated mock records at module load time as a dev-time sanity check
- kept the mock data source encapsulated and returned cloned records from read helpers

## Why

This creates the data/domain foundation needed for the next UI slices:
- request table rendering
- detail panel
- search/filter/sort
- approve/reject flow
- loading / empty / error states

The implementation stays intentionally simple and interview-defensible:
- no extra dependencies
- no database
- no server actions yet
- no premature abstractions

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`

## Notes

- no UI was implemented in this PR
- no client components were added
- no new packages or tooling changes were introduced
- mock data remains feature-local and intentionally temporary