### PR TITLE
chore: ignore private local documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+.local/
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary

Adds a gitignore rule for private local-only documentation and notes.

## What changed

- added `.local/` to `.gitignore`

## Why

This allows local project notes and private documentation to exist outside version control while keeping the repository clean.

## Verification

- no runtime code changed
- `.local/` is ignored by Git