### PR TITLE
feat: render server-loaded dashboard request table

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,6 @@
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #f3f4f6;
+  --foreground: #111827;
 }
 
 html {
@@ -21,7 +14,7 @@ body {
 }
 
 body {
-  min-height: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   color: var(--foreground);
@@ -40,10 +33,4 @@ body {
 a {
   color: inherit;
   text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
-export default function HomePage() {
-  return (
-    <main>
-      <h1>API Access Console</h1>
-      <p>Access request management — coming soon.</p>
-    </main>
-  );
+import { RequestsDashboard } from "@/features/access-requests/components/RequestsDashboard";
+import { fetchAccessRequests } from "@/features/access-requests/mock-data";
+
+export default async function HomePage() {
+  const requests = await fetchAccessRequests();
+
+  return <RequestsDashboard requests={requests} />;
 }

--- a/src/features/access-requests/components/RequestsDashboard.module.css
+++ b/src/features/access-requests/components/RequestsDashboard.module.css
@@ -1,0 +1,69 @@
+.page {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1120px;
+  padding: 2.5rem 1.25rem 3rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.title {
+  font-size: 1.85rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #111827;
+}
+
+.description {
+  color: #4b5563;
+  font-size: 1rem;
+}
+
+.summary {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  padding: 0.8rem 1rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.summaryLabel {
+  color: #6b7280;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.summaryValue {
+  color: #111827;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.tableCard {
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.8rem;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding-top: 1.75rem;
+  }
+
+  .title {
+    font-size: 1.45rem;
+  }
+}

--- a/src/features/access-requests/components/RequestsDashboard.tsx
+++ b/src/features/access-requests/components/RequestsDashboard.tsx
@@ -1,0 +1,29 @@
+import type { AccessRequest } from "../types";
+import { RequestsTable } from "./RequestsTable";
+import styles from "./RequestsDashboard.module.css";
+
+type RequestsDashboardProps = {
+  requests: readonly AccessRequest[];
+};
+
+export function RequestsDashboard({ requests }: RequestsDashboardProps) {
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>API Access Requests</h1>
+        <p className={styles.description}>
+          Review current requests across teams and environments.
+        </p>
+      </header>
+
+      <section className={styles.summary} aria-label="Request summary">
+        <p className={styles.summaryLabel}>Total requests</p>
+        <p className={styles.summaryValue}>{requests.length}</p>
+      </section>
+
+      <section className={styles.tableCard} aria-label="Access request table">
+        <RequestsTable requests={requests} />
+      </section>
+    </main>
+  );
+}

--- a/src/features/access-requests/components/RequestsTable.module.css
+++ b/src/features/access-requests/components/RequestsTable.module.css
@@ -1,0 +1,144 @@
+.tableContainer {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.table th {
+  color: #4b5563;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.table td {
+  color: #111827;
+  font-size: 0.9rem;
+}
+
+.requesterBlock {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.requesterName {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.requesterEmail {
+  color: #6b7280;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+.emptyState {
+  color: #6b7280;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mobileCards {
+  display: none;
+}
+
+.mobileCard {
+  min-width: 0;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.8rem;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+.mobileCardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.9rem;
+}
+
+.mobileDetails {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.mobileDetailRow {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.mobileDetailRow dt {
+  color: #6b7280;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.mobileDetailRow dd {
+  color: #111827;
+  font-size: 0.92rem;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.mobileEmptyState {
+  color: #6b7280;
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.8rem;
+}
+
+@media (max-width: 639px) {
+  .tableContainer {
+    display: none;
+  }
+
+  .mobileCards {
+    display: grid;
+    gap: 0.9rem;
+  }
+
+  .requesterEmail {
+    font-size: 0.75rem;
+  }
+}

--- a/src/features/access-requests/components/RequestsTable.tsx
+++ b/src/features/access-requests/components/RequestsTable.tsx
@@ -1,0 +1,132 @@
+import type { AccessRequest } from "../types";
+import { StatusBadge } from "./StatusBadge";
+import styles from "./RequestsTable.module.css";
+
+type RequestsTableProps = {
+  requests: readonly AccessRequest[];
+};
+
+const submittedDateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function formatSubmittedDate(submittedAt: string): string {
+  const date = new Date(submittedAt);
+  if (Number.isNaN(date.getTime())) {
+    return "Invalid date";
+  }
+  return submittedDateFormatter.format(date);
+}
+
+export function RequestsTable({ requests }: RequestsTableProps) {
+  return (
+    <>
+      <div className={styles.tableContainer}>
+        <table className={styles.table}>
+          <caption className={styles.visuallyHidden}>
+            API access requests by requester, team, API, environment, access level,
+            submitted date, and status.
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Requester</th>
+              <th scope="col">Team</th>
+              <th scope="col">API</th>
+              <th scope="col">Environment</th>
+              <th scope="col">Access</th>
+              <th scope="col">Submitted</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {requests.length === 0 ? (
+              <tr>
+                <td colSpan={7} className={styles.emptyState}>
+                  No access requests found.
+                </td>
+              </tr>
+            ) : (
+              requests.map((request) => (
+                <tr key={request.id}>
+                  <td>
+                    <div className={styles.requesterBlock}>
+                      <span className={styles.requesterName}>
+                        {request.requesterName}
+                      </span>
+                      <span className={styles.requesterEmail}>
+                        {request.requesterEmail}
+                      </span>
+                    </div>
+                  </td>
+                  <td>{request.team}</td>
+                  <td>{request.apiName}</td>
+                  <td className={styles.capitalize}>{request.environment}</td>
+                  <td className={styles.capitalize}>{request.accessLevel}</td>
+                  <td>
+                    <time dateTime={request.submittedAt}>
+                      {formatSubmittedDate(request.submittedAt)}
+                    </time>
+                  </td>
+                  <td>
+                    <StatusBadge status={request.status} />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className={styles.mobileCards} aria-label="Access requests">
+        {requests.length === 0 ? (
+          <p className={styles.mobileEmptyState}>No access requests found.</p>
+        ) : (
+          requests.map((request) => (
+            <article key={request.id} className={styles.mobileCard}>
+              <div className={styles.mobileCardHeader}>
+                <div className={styles.requesterBlock}>
+                  <span className={styles.requesterName}>
+                    {request.requesterName}
+                  </span>
+                  <span className={styles.requesterEmail}>
+                    {request.requesterEmail}
+                  </span>
+                </div>
+                <StatusBadge status={request.status} />
+              </div>
+
+              <dl className={styles.mobileDetails}>
+                <div className={styles.mobileDetailRow}>
+                  <dt>Team</dt>
+                  <dd>{request.team}</dd>
+                </div>
+                <div className={styles.mobileDetailRow}>
+                  <dt>API</dt>
+                  <dd>{request.apiName}</dd>
+                </div>
+                <div className={styles.mobileDetailRow}>
+                  <dt>Environment</dt>
+                  <dd className={styles.capitalize}>{request.environment}</dd>
+                </div>
+                <div className={styles.mobileDetailRow}>
+                  <dt>Access</dt>
+                  <dd className={styles.capitalize}>{request.accessLevel}</dd>
+                </div>
+                <div className={styles.mobileDetailRow}>
+                  <dt>Submitted</dt>
+                  <dd>
+                    <time dateTime={request.submittedAt}>
+                      {formatSubmittedDate(request.submittedAt)}
+                    </time>
+                  </dd>
+                </div>
+              </dl>
+            </article>
+          ))
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/features/access-requests/components/StatusBadge.module.css
+++ b/src/features/access-requests/components/StatusBadge.module.css
@@ -1,0 +1,25 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.pending {
+  background-color: #fff3d6;
+  color: #8a5a00;
+}
+
+.approved {
+  background-color: #daf4e4;
+  color: #18623d;
+}
+
+.rejected {
+  background-color: #fde2e2;
+  color: #8a1f1f;
+}

--- a/src/features/access-requests/components/StatusBadge.tsx
+++ b/src/features/access-requests/components/StatusBadge.tsx
@@ -1,0 +1,26 @@
+import type { AccessStatus } from "../types";
+import styles from "./StatusBadge.module.css";
+
+type StatusBadgeProps = {
+  status: AccessStatus;
+};
+
+const STATUS_LABELS: Record<AccessStatus, string> = {
+  pending: "Pending",
+  approved: "Approved",
+  rejected: "Rejected",
+};
+
+const STATUS_CLASS_NAMES: Record<AccessStatus, string> = {
+  pending: styles.pending,
+  approved: styles.approved,
+  rejected: styles.rejected,
+};
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <span className={`${styles.badge} ${STATUS_CLASS_NAMES[status]}`}>
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Builds the first real dashboard UI for the API Access Console by server-loading access requests and rendering them in a clean internal-tool table.

Closes #3

## What changed

- updated `src/app/page.tsx` to load access requests on the server
- added `RequestsDashboard` for page-level dashboard presentation
- added `RequestsTable` for rendering the request list
- added `StatusBadge` for status display
- added scoped CSS Modules for the new dashboard/table/badge components
- introduced a responsive table/cards presentation pattern for narrower screens
- updated `src/app/globals.css` to use a consistent light app shell

## Why

This creates the first meaningful UI slice of the project and gives the app a real dashboard surface without introducing interactivity or mutation logic too early.

It also preserves the intended implementation order:
- app shell first
- domain/data layer second
- read-only dashboard UI next

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- manually reviewed in local dev at desktop and narrow/mobile widths

## Notes

- no search, filter, or sort yet
- no detail panel yet
- no row selection yet
- no approve/reject actions yet
- no new dependencies added