### PR TITLE
feat: add dashboard search, filter, and sort controls

### DIFF
--- a/src/features/access-requests/components/RequestsDashboard.module.css
+++ b/src/features/access-requests/components/RequestsDashboard.module.css
@@ -46,7 +46,7 @@
 
 .summaryValue {
   color: #111827;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
 }
 
@@ -56,6 +56,23 @@
   border-radius: 0.8rem;
   overflow: hidden;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+.clearFilters {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #2563eb;
+  font-size: 0.875rem;
+  font-family: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.toolbarActions {
+  display: flex;
+  justify-content: flex-end;
+  margin: -0.25rem 0 1rem;
 }
 
 @media (max-width: 768px) {

--- a/src/features/access-requests/components/RequestsDashboard.tsx
+++ b/src/features/access-requests/components/RequestsDashboard.tsx
@@ -1,12 +1,60 @@
-import type { AccessRequest } from "../types";
+"use client";
+
+import { useState } from "react";
+import type { AccessRequest, AccessStatus, Environment } from "../types";
 import { RequestsTable } from "./RequestsTable";
+import { RequestsToolbar } from "./RequestsToolbar";
+import type { SortOrder } from "./RequestsToolbar";
 import styles from "./RequestsDashboard.module.css";
 
 type RequestsDashboardProps = {
   requests: readonly AccessRequest[];
 };
 
+function matchesSearch(request: AccessRequest, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    request.requesterName.toLowerCase().includes(q) ||
+    request.requesterEmail.toLowerCase().includes(q) ||
+    request.team.toLowerCase().includes(q) ||
+    request.apiName.toLowerCase().includes(q)
+  );
+}
+
 export function RequestsDashboard({ requests }: RequestsDashboardProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<AccessStatus | "">("");
+  const [environmentFilter, setEnvironmentFilter] = useState<Environment | "">(
+    ""
+  );
+  const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+
+  const trimmedSearch = searchQuery.trim();
+  const normalizedSearch = trimmedSearch.toLowerCase();
+  const hasActiveFilters =
+    trimmedSearch !== "" || statusFilter !== "" || environmentFilter !== "";
+
+  const filteredRequests = requests
+    .filter((r) => {
+      if (statusFilter !== "" && r.status !== statusFilter) return false;
+      if (environmentFilter !== "" && r.environment !== environmentFilter)
+        return false;
+      if (normalizedSearch !== "" && !matchesSearch(r, normalizedSearch))
+        return false;
+      return true;
+    })
+    .sort((a, b) => {
+      const diff = Date.parse(a.submittedAt) - Date.parse(b.submittedAt);
+      return sortOrder === "newest" ? -diff : diff;
+    });
+
+  function clearFilters() {
+    setSearchQuery("");
+    setStatusFilter("");
+    setEnvironmentFilter("");
+    setSortOrder("newest");
+  }
+
   return (
     <main className={styles.page}>
       <header className={styles.header}>
@@ -16,13 +64,45 @@ export function RequestsDashboard({ requests }: RequestsDashboardProps) {
         </p>
       </header>
 
+      <RequestsToolbar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+        environmentFilter={environmentFilter}
+        onEnvironmentChange={setEnvironmentFilter}
+        sortOrder={sortOrder}
+        onSortChange={setSortOrder}
+      />
+
+      {hasActiveFilters && (
+        <div className={styles.toolbarActions}>
+          <button
+            type="button"
+            className={styles.clearFilters}
+            onClick={clearFilters}
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
+
       <section className={styles.summary} aria-label="Request summary">
-        <p className={styles.summaryLabel}>Total requests</p>
-        <p className={styles.summaryValue}>{requests.length}</p>
+        <p className={styles.summaryLabel}>Showing</p>
+        <p className={styles.summaryValue}>
+          {filteredRequests.length} of {requests.length} requests
+        </p>
       </section>
 
       <section className={styles.tableCard} aria-label="Access request table">
-        <RequestsTable requests={requests} />
+        <RequestsTable
+          requests={filteredRequests}
+          emptyMessage={
+            hasActiveFilters
+              ? "No requests match your current filters."
+              : "No access requests found."
+          }
+        />
       </section>
     </main>
   );

--- a/src/features/access-requests/components/RequestsTable.tsx
+++ b/src/features/access-requests/components/RequestsTable.tsx
@@ -4,6 +4,7 @@ import styles from "./RequestsTable.module.css";
 
 type RequestsTableProps = {
   requests: readonly AccessRequest[];
+  emptyMessage?: string;
 };
 
 const submittedDateFormatter = new Intl.DateTimeFormat("en-US", {
@@ -20,7 +21,10 @@ function formatSubmittedDate(submittedAt: string): string {
   return submittedDateFormatter.format(date);
 }
 
-export function RequestsTable({ requests }: RequestsTableProps) {
+export function RequestsTable({
+  requests,
+  emptyMessage = "No access requests found.",
+}: RequestsTableProps) {
   return (
     <>
       <div className={styles.tableContainer}>
@@ -44,7 +48,7 @@ export function RequestsTable({ requests }: RequestsTableProps) {
             {requests.length === 0 ? (
               <tr>
                 <td colSpan={7} className={styles.emptyState}>
-                  No access requests found.
+                  {emptyMessage}
                 </td>
               </tr>
             ) : (
@@ -81,7 +85,7 @@ export function RequestsTable({ requests }: RequestsTableProps) {
 
       <div className={styles.mobileCards} aria-label="Access requests">
         {requests.length === 0 ? (
-          <p className={styles.mobileEmptyState}>No access requests found.</p>
+          <p className={styles.mobileEmptyState}>{emptyMessage}</p>
         ) : (
           requests.map((request) => (
             <article key={request.id} className={styles.mobileCard}>

--- a/src/features/access-requests/components/RequestsToolbar.module.css
+++ b/src/features/access-requests/components/RequestsToolbar.module.css
@@ -1,0 +1,64 @@
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  margin-bottom: 1.25rem;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+/* Search control stretches to fill available row width */
+.controlSearch {
+  flex: 1;
+  min-width: 220px;
+}
+
+.label {
+  color: #4b5563;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 0.4rem;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: #111827;
+  background-color: #ffffff;
+  height: 2.25rem;
+}
+
+.input:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+  border-color: #2563eb;
+}
+
+.select {
+  min-width: 140px;
+  border: 1px solid #d1d5db;
+  border-radius: 0.4rem;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: #111827;
+  background-color: #ffffff;
+  cursor: pointer;
+  height: 2.25rem;
+}
+
+.select:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+  border-color: #2563eb;
+}

--- a/src/features/access-requests/components/RequestsToolbar.tsx
+++ b/src/features/access-requests/components/RequestsToolbar.tsx
@@ -1,0 +1,102 @@
+import { AccessStatus, Environment } from "../types";
+import styles from "./RequestsToolbar.module.css";
+
+export type SortOrder = "newest" | "oldest";
+
+type RequestsToolbarProps = {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  statusFilter: AccessStatus | "";
+  onStatusChange: (status: AccessStatus | "") => void;
+  environmentFilter: Environment | "";
+  onEnvironmentChange: (env: Environment | "") => void;
+  sortOrder: SortOrder;
+  onSortChange: (order: SortOrder) => void;
+};
+
+export function RequestsToolbar({
+  searchQuery,
+  onSearchChange,
+  statusFilter,
+  onStatusChange,
+  environmentFilter,
+  onEnvironmentChange,
+  sortOrder,
+  onSortChange,
+}: RequestsToolbarProps) {
+  return (
+    <div className={styles.toolbar}>
+      <div className={`${styles.control} ${styles.controlSearch}`}>
+        <label htmlFor="search-query" className={styles.label}>
+          Search
+        </label>
+        <input
+          type="search"
+          id="search-query"
+          className={styles.input}
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Name, email, team, or API…"
+        />
+      </div>
+
+      <div className={styles.control}>
+        <label htmlFor="status-filter" className={styles.label}>
+          Status
+        </label>
+        <select
+          id="status-filter"
+          className={styles.select}
+          value={statusFilter}
+          onChange={(e) => {
+            const value = e.target.value;
+            onStatusChange(value === "" ? "" : (value as AccessStatus));
+          }}
+        >
+          <option value="">All statuses</option>
+          <option value={AccessStatus.pending}>Pending</option>
+          <option value={AccessStatus.approved}>Approved</option>
+          <option value={AccessStatus.rejected}>Rejected</option>
+        </select>
+      </div>
+
+      <div className={styles.control}>
+        <label htmlFor="env-filter" className={styles.label}>
+          Environment
+        </label>
+        <select
+          id="env-filter"
+          className={styles.select}
+          value={environmentFilter}
+          onChange={(e) => {
+            const value = e.target.value;
+            onEnvironmentChange(value === "" ? "" : (value as Environment));
+          }}
+        >
+          <option value="">All environments</option>
+          <option value={Environment.development}>Development</option>
+          <option value={Environment.staging}>Staging</option>
+          <option value={Environment.production}>Production</option>
+        </select>
+      </div>
+
+      <div className={styles.control}>
+        <label htmlFor="sort-order" className={styles.label}>
+          Sort
+        </label>
+        <select
+          id="sort-order"
+          className={styles.select}
+          value={sortOrder}
+          onChange={(e) => {
+            const value = e.target.value;
+            onSortChange(value === "oldest" ? "oldest" : "newest");
+          }}
+        >
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+        </select>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds client-side dashboard controls for search, filter, and sort while keeping the page server-loaded and the table/cards view read-only.

Closes #4

## What changed

- converted `RequestsDashboard` into the local client boundary for dashboard interactions
- added `RequestsToolbar` for search, status filter, environment filter, and sort controls
- added local derived filtering and sorting logic inside `RequestsDashboard`
- updated the summary copy to show the current visible result count
- added an empty-results message that changes based on whether filters are active
- added a `Clear filters` action when search/filter state is active
- updated `RequestsTable` to accept an optional `emptyMessage` prop
- refined toolbar layout so it remains usable across desktop and smaller screens

## Why

This adds the first meaningful dashboard interactions without expanding the scope into row selection, detail views, or mutation behavior.

It preserves the intended implementation order:
- app shell first
- domain/data layer second
- read-only dashboard UI third
- dashboard interactions fourth

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- manually verified locally:
  - search by requester name, email, team, and API
  - status and environment filters independently and together
  - newest/oldest sorting
  - empty-results state and clear-filters behavior
  - desktop, tablet-ish, and mobile widths

## Notes

- no detail panel yet
- no approve/reject actions yet
- no URL sync yet
- no global state added
- no new dependencies added