### PR TITLE
feat: add light and dark theme toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,35 +1,82 @@
+/* Light theme tokens */
 :root {
-  --background: #f3f4f6;
-  --foreground: #111827;
+  --color-bg: #f3f4f6;
+  --color-surface: #ffffff;
+  --color-border: #d1d5db;
+  --color-border-subtle: #e5e7eb;
+
+  --color-text-primary: #111827;
+  --color-text-secondary: #4b5563;
+  --color-text-muted: #6b7280;
+  --color-accent: #2563eb;
+
+  --color-badge-pending-bg: #fff3d6;
+  --color-badge-pending-text: #8a5a00;
+  --color-badge-approved-bg: #daf4e4;
+  --color-badge-approved-text: #18623d;
+  --color-badge-rejected-bg: #fde2e2;
+  --color-badge-rejected-text: #8a1f1f;
 }
 
+/* Theme-specific color-scheme hints for native browser UI */
+html[data-theme="light"] {
+  color-scheme: light;
+}
+
+/* Dark theme token overrides */
+html[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-bg: #0f1117;
+  --color-surface: #1a1d27;
+  --color-border: #2d3148;
+  --color-border-subtle: #252836;
+
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+  --color-accent: #60a5fa;
+
+  --color-badge-pending-bg: #3d2900;
+  --color-badge-pending-text: #fcd34d;
+  --color-badge-approved-bg: #052e16;
+  --color-badge-approved-text: #86efac;
+  --color-badge-rejected-bg: #450a0a;
+  --color-badge-rejected-text: #fca5a5;
+}
+
+/* Root document sizing */
 html {
   height: 100%;
 }
 
+/* Prevent accidental horizontal overflow */
 html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
 }
 
+/* Global app shell defaults */
 body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  color: var(--foreground);
-  background: var(--background);
+  color: var(--color-text-primary);
+  background: var(--color-bg);
   font-family: var(--font-geist-sans), Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Global reset */
 * {
   box-sizing: border-box;
   padding: 0;
   margin: 0;
 }
 
+/* Link defaults */
 a {
   color: inherit;
   text-decoration: none;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { THEME_STORAGE_KEY } from "@/lib/theme";
+
 import "./globals.css";
 
 const geistSans = Geist({
@@ -17,14 +20,24 @@ export const metadata: Metadata = {
   description: "Internal tool for managing API access requests",
 };
 
+// Synchronous inline script: sets data-theme before first paint to prevent flash.
+// Storage key must match THEME_STORAGE_KEY in src/lib/theme.ts.
+const themeInitScript = `(function(){var d=document.documentElement;var p=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';try{var s=localStorage.getItem('${THEME_STORAGE_KEY}');d.setAttribute('data-theme',(s==='light'||s==='dark')?s:p);}catch(e){d.setAttribute('data-theme',p);}})();`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
-      <body>{children}</body>
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body>
+        <ThemeToggle />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/ui/ThemeToggle.module.css
+++ b/src/components/ui/ThemeToggle.module.css
@@ -1,0 +1,27 @@
+.toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1.25rem;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.toggle:hover {
+  background: var(--color-border-subtle);
+  color: var(--color-text-primary);
+}
+
+.toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { isTheme, THEME_STORAGE_KEY, THEME_CHANGE_EVENT } from "@/lib/theme";
+import type { Theme } from "@/lib/theme";
+import styles from "./ThemeToggle.module.css";
+
+function getTheme(): Theme {
+  const value = document.documentElement.dataset.theme;
+  return isTheme(value) ? value : "light";
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  window.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  };
+}
+
+function setTheme(next: Theme): void {
+  document.documentElement.dataset.theme = next;
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, next);
+  } catch {
+    // Ignore storage failures; DOM update still applies.
+  }
+  window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+}
+
+export function ThemeToggle() {
+  const theme = useSyncExternalStore<Theme>(subscribe, getTheme, (): Theme => "light");
+  const nextTheme: Theme = theme === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      type="button"
+      className={styles.toggle}
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      onClick={() => setTheme(nextTheme)}
+    >
+      <span aria-hidden="true">
+        {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+      </span>
+    </button>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="6" />
+      <line x1="12" y1="18" x2="12" y2="22" />
+      <line x1="4.93" y1="4.93" x2="7.76" y2="7.76" />
+      <line x1="16.24" y1="16.24" x2="19.07" y2="19.07" />
+      <line x1="2" y1="12" x2="6" y2="12" />
+      <line x1="18" y1="12" x2="22" y2="12" />
+      <line x1="4.93" y1="19.07" x2="7.76" y2="16.24" />
+      <line x1="16.24" y1="7.76" x2="19.07" y2="4.93" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+  );
+}

--- a/src/features/access-requests/components/RequestsDashboard.module.css
+++ b/src/features/access-requests/components/RequestsDashboard.module.css
@@ -16,11 +16,11 @@
   font-size: 1.85rem;
   font-weight: 700;
   line-height: 1.2;
-  color: #111827;
+  color: var(--color-text-primary);
 }
 
 .description {
-  color: #4b5563;
+  color: var(--color-text-secondary);
   font-size: 1rem;
 }
 
@@ -28,8 +28,8 @@
   display: inline-flex;
   flex-direction: column;
   gap: 0.2rem;
-  background-color: #ffffff;
-  border: 1px solid #d1d5db;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   padding: 0.8rem 1rem;
   margin-bottom: 1.25rem;
@@ -37,7 +37,7 @@
 }
 
 .summaryLabel {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -45,14 +45,14 @@
 }
 
 .summaryValue {
-  color: #111827;
+  color: var(--color-text-primary);
   font-size: 1.25rem;
   font-weight: 700;
 }
 
 .tableCard {
-  background-color: #ffffff;
-  border: 1px solid #d1d5db;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 0.8rem;
   overflow: hidden;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
@@ -62,11 +62,16 @@
   background: none;
   border: none;
   padding: 0;
-  color: #2563eb;
+  color: var(--color-accent);
   font-size: 0.875rem;
   font-family: inherit;
   text-decoration: underline;
   cursor: pointer;
+}
+
+.clearFilters:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .toolbarActions {

--- a/src/features/access-requests/components/RequestsTable.module.css
+++ b/src/features/access-requests/components/RequestsTable.module.css
@@ -12,14 +12,14 @@
 
 .table th,
 .table td {
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--color-border-subtle);
   padding: 0.85rem 1rem;
   text-align: left;
   vertical-align: middle;
 }
 
 .table th {
-  color: #4b5563;
+  color: var(--color-text-secondary);
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -27,7 +27,7 @@
 }
 
 .table td {
-  color: #111827;
+  color: var(--color-text-primary);
   font-size: 0.9rem;
 }
 
@@ -44,7 +44,7 @@
 }
 
 .requesterEmail {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-size: 0.8rem;
   overflow-wrap: anywhere;
 }
@@ -54,7 +54,7 @@
 }
 
 .emptyState {
-  color: #6b7280;
+  color: var(--color-text-muted);
   text-align: center;
   padding: 2rem 1rem;
 }
@@ -77,8 +77,8 @@
 
 .mobileCard {
   min-width: 0;
-  background-color: #ffffff;
-  border: 1px solid #d1d5db;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 0.8rem;
   padding: 1rem;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
@@ -105,7 +105,7 @@
 }
 
 .mobileDetailRow dt {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -113,18 +113,18 @@
 }
 
 .mobileDetailRow dd {
-  color: #111827;
+  color: var(--color-text-primary);
   font-size: 0.92rem;
   margin: 0;
   overflow-wrap: anywhere;
 }
 
 .mobileEmptyState {
-  color: #6b7280;
+  color: var(--color-text-muted);
   text-align: center;
   padding: 1.5rem 1rem;
-  background-color: #ffffff;
-  border: 1px solid #d1d5db;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 0.8rem;
 }
 

--- a/src/features/access-requests/components/RequestsToolbar.module.css
+++ b/src/features/access-requests/components/RequestsToolbar.module.css
@@ -19,7 +19,7 @@
 }
 
 .label {
-  color: #4b5563;
+  color: var(--color-text-secondary);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -28,37 +28,37 @@
 
 .input {
   width: 100%;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 0.4rem;
   padding: 0.45rem 0.6rem;
   font-size: 0.875rem;
   font-family: inherit;
-  color: #111827;
-  background-color: #ffffff;
+  color: var(--color-text-primary);
+  background-color: var(--color-surface);
   height: 2.25rem;
 }
 
 .input:focus {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--color-accent);
   outline-offset: 1px;
-  border-color: #2563eb;
+  border-color: var(--color-accent);
 }
 
 .select {
   min-width: 140px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 0.4rem;
   padding: 0.45rem 0.6rem;
   font-size: 0.875rem;
   font-family: inherit;
-  color: #111827;
-  background-color: #ffffff;
+  color: var(--color-text-primary);
+  background-color: var(--color-surface);
   cursor: pointer;
   height: 2.25rem;
 }
 
 .select:focus {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--color-accent);
   outline-offset: 1px;
-  border-color: #2563eb;
+  border-color: var(--color-accent);
 }

--- a/src/features/access-requests/components/StatusBadge.module.css
+++ b/src/features/access-requests/components/StatusBadge.module.css
@@ -10,16 +10,16 @@
 }
 
 .pending {
-  background-color: #fff3d6;
-  color: #8a5a00;
+  background-color: var(--color-badge-pending-bg);
+  color: var(--color-badge-pending-text);
 }
 
 .approved {
-  background-color: #daf4e4;
-  color: #18623d;
+  background-color: var(--color-badge-approved-bg);
+  color: var(--color-badge-approved-text);
 }
 
 .rejected {
-  background-color: #fde2e2;
-  color: #8a1f1f;
+  background-color: var(--color-badge-rejected-bg);
+  color: var(--color-badge-rejected-text);
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,9 @@
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "api-console-theme" as const;
+export const THEME_CHANGE_EVENT = "api-console-theme-change" as const;
+
+/** Narrows an unknown value to Theme. */
+export function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark";
+}


### PR DESCRIPTION
## Summary

SPARE THE EYES, FOR THE LOVE OF ALL THAT IS HOLY!  :)

Adds a small light/dark theme toggle to the API Access Console, including persisted theme preference, pre-hydration theme initialization, and token-based theme support across the existing dashboard UI.

Closes #14

## What changed

- added `src/lib/theme.ts` for shared theme constants and type guard
- added `src/components/ui/ThemeToggle.tsx`
- added `src/components/ui/ThemeToggle.module.css`
- updated `src/app/layout.tsx` to:
  - initialize theme before first paint
  - render the theme toggle from the app shell
- expanded `src/app/globals.css` into a semantic light/dark token layer
- replaced hardcoded colors in the current dashboard CSS Modules with theme tokens:
  - `RequestsDashboard.module.css`
  - `RequestsTable.module.css`
  - `RequestsToolbar.module.css`
  - `StatusBadge.module.css`

## Why

This improves usability and comfort while keeping the implementation small, dependency-free, and consistent with the existing app structure.

It also keeps theming scoped to the current UI surface rather than turning the feature into a broader redesign.

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- manually verified locally:
  - theme toggle switches immediately
  - theme persists across reloads
  - no obvious light/dark flash on load
  - dashboard, toolbar, table/cards, and badges remain readable in both themes
  - desktop and mobile widths remain usable

## Notes

- no new dependencies added
- no Context/provider theming system added
- no feature TSX files were changed for theming
- current loading placeholder behavior remains unchanged