### PR TITLE
feat: add request detail panel

### DIFF
--- a/src/features/access-requests/components/RequestDetailPanel.module.css
+++ b/src/features/access-requests/components/RequestDetailPanel.module.css
@@ -1,0 +1,135 @@
+.panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 400px;
+  height: 100vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: -2px 0 8px rgba(15, 23, 42, 0.08);
+  z-index: 110;
+}
+
+.panelHeader {
+  position: sticky;
+  top: 0;
+  z-index: 111;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.25rem 1rem;
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.panelTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.closeButton {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 0.2rem 0.45rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-family: inherit;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 0.3rem;
+}
+
+.closeButton:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-border-subtle);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.panelBody {
+  flex: 1;
+  padding-bottom: 2rem;
+}
+
+.section {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.section:last-child {
+  border-bottom: none;
+}
+
+.sectionHeading {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.65rem;
+}
+
+.detailList {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.detailRow {
+  display: grid;
+  grid-template-columns: 7.5rem 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.detailLabel {
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+}
+
+.detailValue {
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  overflow-wrap: anywhere;
+  margin: 0;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+.bodyText {
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.emailLink {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.emailLink:hover {
+  text-decoration: underline;
+}
+
+/* Narrow/mobile: full-screen overlay */
+@media (max-width: 899px) {
+  .panel {
+    inset: 0;
+    width: 100%;
+    border-left: none;
+    box-shadow: none;
+  }
+}

--- a/src/features/access-requests/components/RequestDetailPanel.tsx
+++ b/src/features/access-requests/components/RequestDetailPanel.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { AccessRequest } from "../types";
+import { StatusBadge } from "./StatusBadge";
+import styles from "./RequestDetailPanel.module.css";
+
+type RequestDetailPanelProps = {
+  request: AccessRequest | null;
+  onClose: () => void;
+};
+
+const detailDateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+});
+
+function formatDetailDate(isoString: string): string {
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return "Invalid date";
+  return detailDateFormatter.format(date);
+}
+
+/** Detail panel shown when a user selects a request row. Read-only. */
+export function RequestDetailPanel({ request, onClose }: RequestDetailPanelProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the close button whenever a new request is opened.
+  useEffect(() => {
+    if (request !== null) {
+      closeButtonRef.current?.focus();
+    }
+  }, [request]);
+
+  // Close on Escape while the panel is open.
+  useEffect(() => {
+    if (request === null) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [request, onClose]);
+
+  if (request === null) return null;
+
+  return (
+    <aside className={styles.panel} aria-labelledby="detail-panel-title">
+      <div className={styles.panelHeader}>
+        <h2 id="detail-panel-title" className={styles.panelTitle}>
+          {request.requesterName}
+        </h2>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="Close detail panel"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className={styles.panelBody}>
+        {/* Requester identity */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionHeading}>Requester</h3>
+          <dl className={styles.detailList}>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Name</dt>
+              <dd className={styles.detailValue}>{request.requesterName}</dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Email</dt>
+              <dd className={styles.detailValue}>
+                <a
+                  href={`mailto:${request.requesterEmail}`}
+                  className={styles.emailLink}
+                >
+                  {request.requesterEmail}
+                </a>
+              </dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Team</dt>
+              <dd className={styles.detailValue}>{request.team}</dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* Request details */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionHeading}>Request</h3>
+          <dl className={styles.detailList}>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>API</dt>
+              <dd className={styles.detailValue}>{request.apiName}</dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Environment</dt>
+              <dd className={`${styles.detailValue} ${styles.capitalize}`}>
+                {request.environment}
+              </dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Access level</dt>
+              <dd className={`${styles.detailValue} ${styles.capitalize}`}>
+                {request.accessLevel}
+              </dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Status</dt>
+              <dd className={styles.detailValue}>
+                <StatusBadge status={request.status} />
+              </dd>
+            </div>
+            <div className={styles.detailRow}>
+              <dt className={styles.detailLabel}>Submitted</dt>
+              <dd className={styles.detailValue}>
+                <time dateTime={request.submittedAt}>
+                  {formatDetailDate(request.submittedAt)}
+                </time>
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* Justification — always present */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionHeading}>Justification</h3>
+          <p className={styles.bodyText}>{request.justification}</p>
+        </section>
+
+        {/* Reviewer notes — only if present */}
+        {request.reviewerNotes !== undefined && (
+          <section className={styles.section}>
+            <h3 className={styles.sectionHeading}>Reviewer notes</h3>
+            <p className={styles.bodyText}>{request.reviewerNotes}</p>
+          </section>
+        )}
+
+        {/* Decision metadata — only if present */}
+        {request.decision !== undefined && (
+          <section className={styles.section}>
+            <h3 className={styles.sectionHeading}>Decision</h3>
+            <dl className={styles.detailList}>
+              <div className={styles.detailRow}>
+                <dt className={styles.detailLabel}>Reviewed by</dt>
+                <dd className={styles.detailValue}>
+                  {request.decision.reviewedBy}
+                </dd>
+              </div>
+              <div className={styles.detailRow}>
+                <dt className={styles.detailLabel}>Reviewed at</dt>
+                <dd className={styles.detailValue}>
+                  <time dateTime={request.decision.reviewedAt}>
+                    {formatDetailDate(request.decision.reviewedAt)}
+                  </time>
+                </dd>
+              </div>
+            </dl>
+          </section>
+        )}
+
+        {/* Actions placeholder — approve/reject will go here in a future issue */}
+      </div>
+    </aside>
+  );
+}

--- a/src/features/access-requests/components/RequestsDashboard.tsx
+++ b/src/features/access-requests/components/RequestsDashboard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { AccessRequest, AccessStatus, Environment } from "../types";
 import { RequestsTable } from "./RequestsTable";
 import { RequestsToolbar } from "./RequestsToolbar";
+import { RequestDetailPanel } from "./RequestDetailPanel";
 import type { SortOrder } from "./RequestsToolbar";
 import styles from "./RequestsDashboard.module.css";
 
@@ -28,6 +29,7 @@ export function RequestsDashboard({ requests }: RequestsDashboardProps) {
     ""
   );
   const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+  const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
 
   const trimmedSearch = searchQuery.trim();
   const normalizedSearch = trimmedSearch.toLowerCase();
@@ -48,6 +50,12 @@ export function RequestsDashboard({ requests }: RequestsDashboardProps) {
       return sortOrder === "newest" ? -diff : diff;
     });
 
+  // Derived from the full list so the panel stays open when filters change.
+  const selectedRequest =
+    selectedRequestId !== null
+      ? (requests.find((r) => r.id === selectedRequestId) ?? null)
+      : null;
+
   function clearFilters() {
     setSearchQuery("");
     setStatusFilter("");
@@ -56,6 +64,7 @@ export function RequestsDashboard({ requests }: RequestsDashboardProps) {
   }
 
   return (
+    <>
     <main className={styles.page}>
       <header className={styles.header}>
         <h1 className={styles.title}>API Access Requests</h1>
@@ -97,6 +106,8 @@ export function RequestsDashboard({ requests }: RequestsDashboardProps) {
       <section className={styles.tableCard} aria-label="Access request table">
         <RequestsTable
           requests={filteredRequests}
+          selectedRequestId={selectedRequestId}
+          onSelectRequest={setSelectedRequestId}
           emptyMessage={
             hasActiveFilters
               ? "No requests match your current filters."
@@ -105,5 +116,11 @@ export function RequestsDashboard({ requests }: RequestsDashboardProps) {
         />
       </section>
     </main>
+
+    <RequestDetailPanel
+      request={selectedRequest}
+      onClose={() => setSelectedRequestId(null)}
+    />
+    </>
   );
 }

--- a/src/features/access-requests/components/RequestsTable.module.css
+++ b/src/features/access-requests/components/RequestsTable.module.css
@@ -128,7 +128,74 @@
   border-radius: 0.8rem;
 }
 
-@media (max-width: 639px) {
+/* Row selected state */
+.rowSelected td {
+  background-color: var(--color-border-subtle);
+}
+
+/* "View" button column — minimal width, content-sized */
+.actionCell {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.viewButton {
+  background: none;
+  border: none;
+  padding: 0.2rem 0.4rem;
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+}
+
+.viewButton:hover {
+  text-decoration: underline;
+}
+
+.viewButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* Visual indicator when this row's panel is open */
+.viewButtonActive {
+  font-weight: 600;
+}
+
+/* Mobile card selected state */
+.mobileCardSelected {
+  border-color: var(--color-accent);
+}
+
+/* "View details" button on mobile cards */
+.mobileViewButton {
+  display: block;
+  width: 100%;
+  margin-top: 0.85rem;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  color: var(--color-accent);
+  font-size: 0.875rem;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: center;
+}
+
+.mobileViewButton:hover {
+  background-color: var(--color-border-subtle);
+}
+
+.mobileViewButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 899px) {
   .tableContainer {
     display: none;
   }

--- a/src/features/access-requests/components/RequestsTable.tsx
+++ b/src/features/access-requests/components/RequestsTable.tsx
@@ -5,6 +5,8 @@ import styles from "./RequestsTable.module.css";
 type RequestsTableProps = {
   requests: readonly AccessRequest[];
   emptyMessage?: string;
+  selectedRequestId?: string | null;
+  onSelectRequest?: (id: string) => void;
 };
 
 const submittedDateFormatter = new Intl.DateTimeFormat("en-US", {
@@ -24,6 +26,8 @@ function formatSubmittedDate(submittedAt: string): string {
 export function RequestsTable({
   requests,
   emptyMessage = "No access requests found.",
+  selectedRequestId,
+  onSelectRequest,
 }: RequestsTableProps) {
   return (
     <>
@@ -42,18 +46,33 @@ export function RequestsTable({
               <th scope="col">Access</th>
               <th scope="col">Submitted</th>
               <th scope="col">Status</th>
+              {onSelectRequest !== undefined && (
+                <th scope="col" className={styles.visuallyHidden}>
+                  Details
+                </th>
+              )}
             </tr>
           </thead>
           <tbody>
             {requests.length === 0 ? (
               <tr>
-                <td colSpan={7} className={styles.emptyState}>
+                <td
+                  colSpan={onSelectRequest !== undefined ? 8 : 7}
+                  className={styles.emptyState}
+                >
                   {emptyMessage}
                 </td>
               </tr>
             ) : (
               requests.map((request) => (
-                <tr key={request.id}>
+                <tr
+                  key={request.id}
+                  className={
+                    request.id === selectedRequestId
+                      ? styles.rowSelected
+                      : undefined
+                  }
+                >
                   <td>
                     <div className={styles.requesterBlock}>
                       <span className={styles.requesterName}>
@@ -76,6 +95,22 @@ export function RequestsTable({
                   <td>
                     <StatusBadge status={request.status} />
                   </td>
+                  {onSelectRequest !== undefined && (
+                    <td className={styles.actionCell}>
+                      <button
+                        type="button"
+                        className={
+                          request.id === selectedRequestId
+                            ? `${styles.viewButton} ${styles.viewButtonActive}`
+                            : styles.viewButton
+                        }
+                        onClick={() => onSelectRequest(request.id)}
+                        aria-label={`View details for ${request.requesterName}`}
+                      >
+                        View
+                      </button>
+                    </td>
+                  )}
                 </tr>
               ))
             )}
@@ -88,7 +123,14 @@ export function RequestsTable({
           <p className={styles.mobileEmptyState}>{emptyMessage}</p>
         ) : (
           requests.map((request) => (
-            <article key={request.id} className={styles.mobileCard}>
+            <article
+              key={request.id}
+              className={
+                request.id === selectedRequestId
+                  ? `${styles.mobileCard} ${styles.mobileCardSelected}`
+                  : styles.mobileCard
+              }
+            >
               <div className={styles.mobileCardHeader}>
                 <div className={styles.requesterBlock}>
                   <span className={styles.requesterName}>
@@ -127,6 +169,16 @@ export function RequestsTable({
                   </dd>
                 </div>
               </dl>
+              {onSelectRequest !== undefined && (
+                <button
+                  type="button"
+                  className={styles.mobileViewButton}
+                  onClick={() => onSelectRequest(request.id)}
+                  aria-label={`View details for ${request.requesterName}`}
+                >
+                  View details
+                </button>
+              )}
             </article>
           ))
         )}


### PR DESCRIPTION
## Summary

Adds a read-only request detail panel so users can inspect an access request in more detail from the existing dashboard.

Closes #5

## What changed

- added `RequestDetailPanel.tsx`
- added `RequestDetailPanel.module.css`
- updated `RequestsDashboard.tsx` to:
  - track the selected request id
  - derive the selected request from the full request list
  - render the detail panel
- updated `RequestsTable.tsx` to add a clear “View” / “View details” trigger for each request
- updated `RequestsTable.module.css` to support:
  - selected request styling
  - action-cell styling
  - mobile detail trigger styling
- aligned the table/cards breakpoint and detail-panel mobile breakpoint for a more consistent responsive experience

## Why

This adds the next logical read-only interaction layer to the dashboard without expanding into mutations or workflow actions yet.

It preserves the intended implementation order:
- app shell
- domain/data layer
- dashboard UI
- dashboard interactions
- read-only request detail view
- approve/reject actions later

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- manually verified locally:
  - desktop table “View” button opens the panel
  - mobile card “View details” button opens the panel
  - close button works
  - Escape closes the panel
  - selected request styling appears correctly
  - panel stays open when filters change
  - detail content renders correctly, including conditional reviewer notes / decision sections
  - dark and light themes both remain readable
  - production server test on phone behaved correctly

## Notes

- read-only only
- no approve/reject actions yet
- no server actions yet
- no URL synchronization yet
- no new dependencies added
- no modal/focus-trap system added